### PR TITLE
Fix Laravel-bridge CI (illuminate/container dev dep + testable resolver)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "phpstan/phpstan": "^2.1",
         "laravel/pint": "^1.27",
         "illuminate/support": "^10.0|^11.0|^12.0",
-        "vlucas/phpdotenv": "^5.6"
+        "vlucas/phpdotenv": "^5.6",
+        "illuminate/container": "^10.0|^11.0|^12.0"
     },
     "suggest": {
         "illuminate/support": "Aktiviert die Laravel-Bridge: auto-discovertes ServiceProvider bindet die LoggerRegistry an den Laravel-Log-Channel"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38f4395100445578dd58b4931826ddce",
+    "content-hash": "60454f9bfed67d868b1cbbc90ec2c660",
     "packages": [
         {
             "name": "psr/log",
@@ -384,6 +384,68 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2025-05-13T15:08:45+00:00"
+        },
+        {
+            "name": "illuminate/container",
+            "version": "v12.64.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/container.git",
+                "reference": "9abe9dba6b3f5220205ce143069c975a601e4294"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/container/zipball/9abe9dba6b3f5220205ce143069c975a601e4294",
+                "reference": "9abe9dba6b3f5220205ce143069c975a601e4294",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^12.0",
+                "illuminate/reflection": "^12.0",
+                "php": "^8.2",
+                "psr/container": "^1.1.1|^2.0.1",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/polyfill-php85": "^1.33"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0"
+            },
+            "suggest": {
+                "illuminate/auth": "Required to use the Auth attribute",
+                "illuminate/cache": "Required to use the Cache attribute",
+                "illuminate/config": "Required to use the Config attribute",
+                "illuminate/database": "Required to use the DB attribute",
+                "illuminate/filesystem": "Required to use the Storage attribute",
+                "illuminate/log": "Required to use the Log or Context attributes"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Container\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Container package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-03-16T14:05:01+00:00"
         },
         {
             "name": "illuminate/contracts",
@@ -3832,5 +3894,5 @@
     "platform-overrides": {
         "php": "8.2.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Laravel/ErrorToolkitServiceProvider.php
+++ b/src/Laravel/ErrorToolkitServiceProvider.php
@@ -58,8 +58,10 @@ class ErrorToolkitServiceProvider extends ServiceProvider {
         // exist"). Therefore: always resolve against the CURRENT container,
         // and fail soft (null → ErrorLog fallback) instead of throwing.
         LoggerRegistry::setLoggerResolver(function (): ?LoggerInterface {
+            // Container::getInstance() always returns a container; if no 'log'
+            // is bound (no Laravel app / flushed container) we fail soft.
             $app = Container::getInstance();
-            if (!$app instanceof Container || !$app->bound('log')) {
+            if (!$app->bound('log')) {
                 return null; // container gone or flushed → fallback logging
             }
 

--- a/tests/Laravel/ErrorToolkitServiceProviderTest.php
+++ b/tests/Laravel/ErrorToolkitServiceProviderTest.php
@@ -14,6 +14,7 @@ namespace Tests\Laravel;
 
 use ERRORToolkit\Laravel\ErrorToolkitServiceProvider;
 use ERRORToolkit\LoggerRegistry;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\{LoggerInterface, NullLogger};
@@ -30,6 +31,7 @@ class ErrorToolkitServiceProviderTest extends TestCase {
 
     protected function tearDown(): void {
         LoggerRegistry::resetLogger();
+        Container::setInstance(null); // drop the global container set by makeApp()
     }
 
     private function makeApp(?string $channel): Application {
@@ -70,7 +72,13 @@ class ErrorToolkitServiceProviderTest extends TestCase {
             'log' => $logManager,
             default => null,
         });
+        $app->method('bound')->willReturnCallback(fn (string $abstract) => in_array($abstract, ['config', 'log'], true));
         $app->method('basePath')->willReturnCallback(fn ($path = '') => '/tmp/app/' . $path);
+
+        // The resolver resolves against the CURRENT global container
+        // (Container::getInstance()), exactly as Laravel wires it — so the test
+        // registers this app as that global instance.
+        Container::setInstance($app);
 
         return $app;
     }


### PR DESCRIPTION
Fixes the Laravel-bridge CI failure that has kept `main` red since the bridge was added (2026-07-04) — independent of the security-hardening work already merged.

## Root cause
- `illuminate/container` was never in `require-dev`, so PHPStan could not resolve `Illuminate\Container\Container` (6 `class.notFound` errors) and the bridge tests errored.
- The resolver reads the **current global** container (`Container::getInstance()`, by design, to survive app swaps in Octane/queue/PHPUnit), but the tests passed an `Application` mock without registering it as that global instance and without mocking `bound()`.

## Fix
- Add `illuminate/container` to `require-dev`.
- Drop the redundant `instanceof Container` in the resolver (getInstance() always returns one — PHPStan flagged it) and keep the fail-soft `bound('log')` guard.
- Tests: mock `bound()` and register the app via `Container::setInstance()`, reset in `tearDown()`.

Full suite now green: **220 tests, PHPStan clean, Pint passing** (previously 6 PHPStan errors + 3 test failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
